### PR TITLE
Added support for rotate info in exif

### DIFF
--- a/lib/RawPreview.php
+++ b/lib/RawPreview.php
@@ -1,70 +1,119 @@
 <?php
 
-
 namespace OCA\CameraRawPreviews;
 
 use OCP\Preview\IProvider;
 
 class RawPreview implements IProvider {
-        /**
-         * {@inheritDoc}
-         */
-        public function getMimeType() {
-                return '/image\/x-dcraw/';
+    /**
+     * {@inheritDoc}
+     */
+    public function getMimeType() {
+        return '/image\/x-dcraw/';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getThumbnail($path, $maxX, $maxY, $scalingup, $fileview) {
+        $converter = \OC_Helper::findBinaryPath('exiftool');
+        if (empty($converter)) {
+            return false;
         }
-        /**
-         * {@inheritDoc}
-         */
-        public function getThumbnail($path, $maxX, $maxY, $scalingup, $fileview) {
-                $converter = \OC_Helper::findBinaryPath('exiftool');
-                if (empty($converter)) {
-                        return false;
-                }
-                $tmpPath = $fileview->toTmpFile($path);
-                if (!$tmpPath) {
-                        return false;
-                }
-
-                // Creates \Imagick object from bitmap or vector file
-                try {
-                        $im = $this->getResizedPreview($tmpPath, $maxX, $maxY);
-                } catch (\Exception $e) {
-                        \OCP\Util::writeLog('core', 'Camera Raw Previews: ' . $e->getmessage(), \OCP\Util::ERROR);
-                        return false;
-                }
-
-                
-                $im->setImageFormat('jpg');
-                $im->setImageCompressionQuality(90);
-                //new bitmap image object
-                $image = new \OC_Image($im);
-                // $image->loadFromData($im);
-                //check if image object is valid
-                return $image->valid() ? $image : false;
+        $tmpPath = $fileview->toTmpFile($path);
+        if (!$tmpPath) {
+            return false;
         }
 
-        protected function getResizedPreview($tmpPath, $maxX, $maxY) {
-            $converter = \OC_Helper::findBinaryPath('exiftool');
-            $im = new \Imagick();
-            $im->readImageBlob(shell_exec($converter . " -b -PreviewImage " . escapeshellarg($tmpPath)));
-            if (!$im->valid()) {
-                return false;
-            }
-            $im = $this->resize($im, $maxX, $maxY);
+        // Creates \Imagick object from bitmap or vector file
+        try {
+            $im = $this->getResizedPreview($tmpPath, $maxX, $maxY, $converter);
+        } catch (\Exception $e) {
+            \OCP\Util::writeLog('core', 'Camera Raw Previews: ' . $e->getmessage(), \OCP\Util::ERROR);
+            return false;
+        }
+        finally {
             unlink($tmpPath);
-            return $im;
-  	}
-        protected function resize($im, $maxX, $maxY) {
-		list($previewWidth, $previewHeight) = array_values($im->getImageGeometry());
+        }
 
-		if ($previewWidth > $maxX || $previewHeight > $maxY) {
-			$im->resizeImage($maxX, $maxY, \imagick::FILTER_CATROM, 1, true);
-		}
+        $im->setImageFormat('jpg');
+        $im->setImageCompressionQuality(90);
+        //new bitmap image object
+        $image = new \OC_Image($im);
+        //check if image object is valid
+        return $image->valid() ? $image : false;
+    }
+        
+    private function getResizedPreview($tmpPath, $maxX, $maxY, $converter) {
+        $converter = \OC_Helper::findBinaryPath('exiftool');
+        $im = new \Imagick();
+        $im->readImageBlob(shell_exec($converter . " -b -PreviewImage " . escapeshellarg($tmpPath)));
 
-		return $im;
-	}
-	public function isAvailable(\OCP\Files\FileInfo $file) {
-		return $file->getSize() > 0;
-	}
-   
+        if (!$im->valid()) {
+            return false;
+        }
+
+        $this->rotateImageIfNeeded($im, $tmpPath);
+        $this->resize($im, $maxX, $maxY);
+#        unlink($tmpPath);
+        return $im;
+    }
+
+    private function rotateImageIfNeeded(\Imagick &$im, $path) {
+        $rotate = 0;
+        $flip = false;
+
+        $rotation = shell_exec($converter . " -n -b -Orientation " . escapeshellarg($path));
+        if ($rotation) {
+            switch ($rotation) {
+                case "2":
+                    $rotate = 180;
+                    $flip = true;
+                    break;
+                case "3":
+                    $rotate = 180;
+                    break;
+                case "4":
+                    $flip = true;
+                    break;
+                case "5":
+                    $rotate = 270;
+                    $flip = true;
+                    break;
+                case "6":
+                    $rotate = 90;
+                    break;
+                case "7":
+                    $rotate = 90;
+                    $flip = true;
+                    break;
+                case "8":
+                    $rotate = 270;
+                    break;
+            }
+        }
+        else {
+            $rotate = shell_exec($converter . " -b -Rotation " . escapeshellarg($path));
+        }
+        if ($rotate) {
+            $im->rotateImage(new \ImagickPixel(), $rotate);
+        }
+        if ($flip) {
+            $im->flipImage();
+        }
+    }
+
+    private function resize(\Imagick &$im, $maxX, $maxY) {
+        list($previewWidth, $previewHeight) = array_values($im->getImageGeometry());
+
+        if ($previewWidth > $maxX || $previewHeight > $maxY) {
+            $im->resizeImage($maxX, $maxY, \imagick::FILTER_CATROM, 1, true);
+        }
+
+        return $im;
+    }
+
+    public function isAvailable(\OCP\Files\FileInfo $file) {
+        return $file->getSize() > 0;
+    }
 }

--- a/lib/RawPreview.php
+++ b/lib/RawPreview.php
@@ -55,7 +55,6 @@ class RawPreview implements IProvider {
 
         $this->rotateImageIfNeeded($im, $tmpPath);
         $this->resize($im, $maxX, $maxY);
-#        unlink($tmpPath);
         return $im;
     }
 


### PR DESCRIPTION
I added support for rotation data saved in a photo's exif information. It could probably be made prettier, but it's working for me for now.

I also think I fixed a potential leak with $tmpPath, but my PHP knowledge is several year outdated, so I'm not 100 % sure what's right or wrong.