### PR TITLE
Rotation not working due to undefined converter variable

### DIFF
--- a/lib/RawPreview.php
+++ b/lib/RawPreview.php
@@ -59,6 +59,7 @@ class RawPreview implements IProvider {
     }
 
     private function rotateImageIfNeeded(\Imagick &$im, $path) {
+        $converter = \OC_Helper::findBinaryPath('exiftool');
         $rotate = 0;
         $flip = false;
 


### PR DESCRIPTION
The rotation method didn't work in my NC 12.0.4 installation, as the $converter was not defined. Log was full of messages like this:

`Undefined variable: converter at /usr/local/www/nginx/apps/camerarawpreviews/lib/RawPreview.php#95`
`Undefined variable: converter at /usr/local/www/nginx/apps/camerarawpreviews/lib/RawPreview.php#65`