### PR TITLE
adjust max-version to current version of nextcloud

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@
     <bugs>https://github.com/cowai/camerarawpreviews/issues</bugs>
     <dependencies>
         <owncloud min-version="10.0" max-version="10.0" />
-        <nextcloud min-version="11" max-version="14" />
+        <nextcloud min-version="11" max-version="15" />
     </dependencies>
     <types><filesystem/></types>
 </info>


### PR DESCRIPTION
The app seems to work fine on the updated version of nextcloud, namely 15. 